### PR TITLE
fix: Add workflow paths to security scan triggers

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,6 +16,7 @@ on:
       - "requirements*.txt"
       - "Dockerfile"
       - "docker-compose.yml"
+      - ".github/workflows/**"
   push:
     branches: [main]
   schedule:


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/**` to the security workflow's path filter
- Ensures security scans run on PRs that modify workflow files
- Fixes issue where required checks never report status for dependabot workflow update PRs

## Test plan
- [ ] Verify this PR triggers the security workflow
- [ ] Merge this first, then the dependabot PR (#24) should have all required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)