### PR TITLE
fix: Expand security workflow path filters

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,11 +12,11 @@ on:
       - "**.ts"
       - "**.tsx"
       - "**.js"
-      - "package*.json"
-      - "requirements*.txt"
+      - "**/package*.json"
+      - "**/requirements*.txt"
       - "Dockerfile"
       - "docker-compose.yml"
-      - ".github/workflows/**"
+      - ".github/**"
   push:
     branches: [main]
   schedule:


### PR DESCRIPTION
## Summary
- Use `**/package*.json` to match subdirectory package files (fixes release PRs)
- Use `**/requirements*.txt` for recursive requirements matching
- Use `.github/**` to trigger on all GitHub config changes

This ensures security checks run for PRs that modify GitHub config files like FUNDING.yml or release-please manifests.

Fixes blocked PRs: #15, #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)