### PR TITLE
fix: populate state for discussions found by ProductBoard ID

### DIFF
--- a/scripts/productboard-sync/sync.ts
+++ b/scripts/productboard-sync/sync.ts
@@ -394,9 +394,25 @@ export async function syncToDiscussions(ideas: ProductBoardIdea[]): Promise<void
   console.log('\nChecking for manually-created discussions to import...');
   const matchedDiscussionIds = new Set<string>();
   for (const idea of ideas) {
-    // Skip if already tracked by ProductBoard ID
+    // If discussion exists by ProductBoard ID, ensure state entry exists
     if (existingByPbId.has(idea.id)) {
-      matchedDiscussionIds.add(existingByPbId.get(idea.id)!.id);
+      const disc = existingByPbId.get(idea.id)!;
+      matchedDiscussionIds.add(disc.id);
+      // Ensure state entry exists (fixes bug where state wasn't populated)
+      if (!state.trackedIdeas[idea.id]) {
+        console.log(`  Importing existing discussion #${disc.number} for "${idea.title}"`);
+        state.trackedIdeas[idea.id] = {
+          discussionId: disc.id,
+          discussionNumber: disc.number,
+          status: disc.closed ? 'closed' : 'open',
+          lastVoteCount: idea.votes,
+          lastProductBoardStatus: idea.status,
+          githubVotes: disc.thumbsUpCount,
+          closedReason: getClosedReason(disc),
+          closedAt: disc.closedAt ?? undefined,
+          source: 'productboard',
+        };
+      }
       continue;
     }
     if (state.trackedIdeas[idea.id]?.discussionNumber) continue;


### PR DESCRIPTION
## Summary
- Fixes bug where discussions found by ProductBoard ID weren't being added to `state.trackedIdeas`
- This caused the export to only find 3 ideas instead of all 13 that had discussions

## Root Cause
When sync found existing discussions via their `<!-- productboard-id: xxx -->` marker, it was:
1. Adding to `matchedDiscussionIds`
2. But NOT adding entries to `state.trackedIdeas`

The export filters by `state[idea.id]?.discussionNumber`, so these ideas were missing.

## Test plan
- [ ] Re-run the ProductBoard sync workflow
- [ ] Verify all 13 feasible ideas are exported to `ideas.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)