### PR TITLE
fix: clean up orphaned github-XX entries when matched to ProductBoard ideas

### DIFF
--- a/scripts/productboard-sync/sync.ts
+++ b/scripts/productboard-sync/sync.ts
@@ -413,6 +413,12 @@ export async function syncToDiscussions(ideas: ProductBoardIdea[]): Promise<void
           source: 'productboard',
         };
       }
+      // Clean up orphaned github-XX entry if it exists for this discussion
+      const githubKey = `github-${disc.number}`;
+      if (state.trackedIdeas[githubKey]) {
+        console.log(`  Removing orphaned ${githubKey} (now tracked as ProductBoard idea)`);
+        delete state.trackedIdeas[githubKey];
+      }
       continue;
     }
     if (state.trackedIdeas[idea.id]?.discussionNumber) continue;
@@ -435,6 +441,12 @@ export async function syncToDiscussions(ideas: ProductBoardIdea[]): Promise<void
       // Add to the map so we don't create a duplicate
       existingByPbId.set(idea.id, matchingDisc);
       matchedDiscussionIds.add(matchingDisc.id);
+      // Clean up orphaned github-XX entry if it exists
+      const githubKey = `github-${matchingDisc.number}`;
+      if (state.trackedIdeas[githubKey]) {
+        console.log(`  Removing orphaned ${githubKey} (now tracked as ProductBoard idea)`);
+        delete state.trackedIdeas[githubKey];
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes duplicate entries where the same idea appears as both a ProductBoard idea AND a GitHub-only idea.

## Root Cause
When discussions were originally created manually (before the ProductBoard ID marker was added), they were stored as `github-XX` entries. Later when matched to ProductBoard ideas, the old entries weren't being cleaned up.

## Fix
When a discussion is matched to a ProductBoard idea (by ID or title), any existing `github-XX` entry for the same discussion number is now removed.

## Test plan
- [ ] Re-run ProductBoard sync workflow
- [ ] Verify the 4 duplicate ideas are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)