### PR TITLE
chore: update productboard sync state and ideas data

### DIFF
--- a/data/ideas.json
+++ b/data/ideas.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-01-05T06:14:56.671Z",
+  "generatedAt": "2026-01-05T06:37:08.745Z",
   "votesThreshold": 500,
-  "totalIdeas": 15,
-  "openCount": 15,
+  "totalIdeas": 14,
+  "openCount": 14,
   "closedCount": 0,
   "ideas": [
     {
@@ -168,20 +168,6 @@
       "productboardUrl": null,
       "discussionUrl": "https://github.com/GraysonCAdams/eclosion-for-monarch/discussions/39",
       "discussionNumber": 39,
-      "status": "open",
-      "closedReason": null,
-      "closedAt": null,
-      "source": "github"
-    },
-    {
-      "id": "github-31",
-      "title": "Budget income by paycheck, year or quarter (not just monthly)",
-      "description": "1,318\nPlan Budget & Forecast\nView on Monarch's Roadmap",
-      "votes": 0,
-      "category": "Community",
-      "productboardUrl": null,
-      "discussionUrl": "https://github.com/GraysonCAdams/eclosion-for-monarch/discussions/31",
-      "discussionNumber": 31,
       "status": "open",
       "closedReason": null,
       "closedAt": null,

--- a/scripts/productboard-sync/state.json
+++ b/scripts/productboard-sync/state.json
@@ -1,5 +1,5 @@
 {
-  "lastSync": "2026-01-05T06:14:55.811Z",
+  "lastSync": "2026-01-05T06:37:07.886Z",
   "trackedIdeas": {
     "cf1f8240-67ae-4b18-a966-0d669813f07a": {
       "discussionId": "D_kwDOQyteiM4AjgiZ",
@@ -18,17 +18,6 @@
       "source": "github",
       "title": "Associate 2 transactions together",
       "description": "2,776\nTransactions\nView on Monarch's Roadmap",
-      "category": "Community"
-    },
-    "github-31": {
-      "discussionId": "D_kwDOQyteiM4Ajgau",
-      "discussionNumber": 31,
-      "status": "open",
-      "lastVoteCount": 0,
-      "githubVotes": 0,
-      "source": "github",
-      "title": "Budget income by paycheck, year or quarter (not just monthly)",
-      "description": "1,318\nPlan Budget & Forecast\nView on Monarch's Roadmap",
       "category": "Community"
     },
     "0baf9e8a-6b1b-47c7-98f8-fb67accb1dac": {


### PR DESCRIPTION
Automated ProductBoard sync update.

This PR updates:
- `scripts/productboard-sync/state.json` - Sync state tracking
- `data/ideas.json` - Exported ideas for frontend

🤖 Generated by the ProductBoard Sync workflow