### PR TITLE
chore: update productboard sync state and ideas data

### DIFF
--- a/data/ideas.json
+++ b/data/ideas.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-01-05T06:41:29.980Z",
+  "generatedAt": "2026-01-05T06:46:23.805Z",
   "votesThreshold": 500,
   "totalIdeas": 14,
   "openCount": 14,
@@ -174,20 +174,6 @@
       "source": "productboard"
     },
     {
-      "id": "github-39",
-      "title": "Associate 2 transactions together",
-      "description": "2,776\nTransactions\nView on Monarch's Roadmap",
-      "votes": 0,
-      "category": "Community",
-      "productboardUrl": null,
-      "discussionUrl": "https://github.com/GraysonCAdams/eclosion-for-monarch/discussions/39",
-      "discussionNumber": 39,
-      "status": "open",
-      "closedReason": null,
-      "closedAt": null,
-      "source": "github"
-    },
-    {
       "id": "github-53",
       "title": "Notes field on categories or merchants",
       "description": "688\nDashboard & System Wide\nView on Monarch's Roadmap",
@@ -196,6 +182,20 @@
       "productboardUrl": null,
       "discussionUrl": "https://github.com/GraysonCAdams/eclosion-for-monarch/discussions/53",
       "discussionNumber": 53,
+      "status": "open",
+      "closedReason": null,
+      "closedAt": null,
+      "source": "github"
+    },
+    {
+      "id": "github-39",
+      "title": "Associate 2 transactions together",
+      "description": "2,777\nTransactions\nView on Monarch's Roadmap",
+      "votes": 0,
+      "category": "Community",
+      "productboardUrl": null,
+      "discussionUrl": "https://github.com/GraysonCAdams/eclosion-for-monarch/discussions/39",
+      "discussionNumber": 39,
       "status": "open",
       "closedReason": null,
       "closedAt": null,

--- a/scripts/productboard-sync/state.json
+++ b/scripts/productboard-sync/state.json
@@ -1,5 +1,5 @@
 {
-  "lastSync": "2026-01-05T06:41:29.082Z",
+  "lastSync": "2026-01-05T06:46:22.931Z",
   "trackedIdeas": {
     "cf1f8240-67ae-4b18-a966-0d669813f07a": {
       "discussionId": "D_kwDOQyteiM4AjgiZ",
@@ -107,6 +107,28 @@
       "lastProductBoardStatus": "idea",
       "githubVotes": 0,
       "source": "productboard"
+    },
+    "github-53": {
+      "discussionId": "D_kwDOQyteiM4Ajgs1",
+      "discussionNumber": 53,
+      "status": "open",
+      "lastVoteCount": 0,
+      "githubVotes": 0,
+      "source": "github",
+      "title": "Notes field on categories or merchants",
+      "description": "688\nDashboard & System Wide\nView on Monarch's Roadmap",
+      "category": "Community"
+    },
+    "github-39": {
+      "discussionId": "D_kwDOQyteiM4Ajga2",
+      "discussionNumber": 39,
+      "status": "open",
+      "lastVoteCount": 0,
+      "githubVotes": 0,
+      "source": "github",
+      "title": "Associate 2 transactions together",
+      "description": "2,777\nTransactions\nView on Monarch's Roadmap",
+      "category": "Community"
     }
   }
 }


### PR DESCRIPTION
Automated ProductBoard sync update.

This PR updates:
- `scripts/productboard-sync/state.json` - Sync state tracking
- `data/ideas.json` - Exported ideas for frontend

🤖 Generated by the ProductBoard Sync workflow