### PR TITLE
chore: update productboard sync state and ideas data

### DIFF
--- a/data/ideas.json
+++ b/data/ideas.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-01-05T06:41:29.980Z",
+  "generatedAt": "2026-01-05T06:49:04.780Z",
   "votesThreshold": 500,
-  "totalIdeas": 14,
-  "openCount": 14,
+  "totalIdeas": 12,
+  "openCount": 12,
   "closedCount": 0,
   "ideas": [
     {
@@ -172,34 +172,6 @@
       "closedReason": null,
       "closedAt": null,
       "source": "productboard"
-    },
-    {
-      "id": "github-39",
-      "title": "Associate 2 transactions together",
-      "description": "2,776\nTransactions\nView on Monarch's Roadmap",
-      "votes": 0,
-      "category": "Community",
-      "productboardUrl": null,
-      "discussionUrl": "https://github.com/GraysonCAdams/eclosion-for-monarch/discussions/39",
-      "discussionNumber": 39,
-      "status": "open",
-      "closedReason": null,
-      "closedAt": null,
-      "source": "github"
-    },
-    {
-      "id": "github-53",
-      "title": "Notes field on categories or merchants",
-      "description": "688\nDashboard & System Wide\nView on Monarch's Roadmap",
-      "votes": 0,
-      "category": "Community",
-      "productboardUrl": null,
-      "discussionUrl": "https://github.com/GraysonCAdams/eclosion-for-monarch/discussions/53",
-      "discussionNumber": 53,
-      "status": "open",
-      "closedReason": null,
-      "closedAt": null,
-      "source": "github"
     }
   ]
 }

--- a/scripts/productboard-sync/state.json
+++ b/scripts/productboard-sync/state.json
@@ -1,5 +1,5 @@
 {
-  "lastSync": "2026-01-05T06:41:29.082Z",
+  "lastSync": "2026-01-05T06:49:03.982Z",
   "trackedIdeas": {
     "cf1f8240-67ae-4b18-a966-0d669813f07a": {
       "discussionId": "D_kwDOQyteiM4AjgiZ",


### PR DESCRIPTION
Automated ProductBoard sync update.

This PR updates:
- `scripts/productboard-sync/state.json` - Sync state tracking
- `data/ideas.json` - Exported ideas for frontend

🤖 Generated by the ProductBoard Sync workflow