### PR TITLE
chore: update contributor attribution data

### DIFF
--- a/frontend/src/data/contributors.json
+++ b/frontend/src/data/contributors.json
@@ -1,0 +1,45 @@
+{
+  "generatedAt": "2026-01-06T05:07:49.711Z",
+  "features": {
+    "recurring": {
+      "featureId": "recurring",
+      "ideator": {
+        "username": "GraysonCAdams",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/51373669?v=4",
+        "profileUrl": "https://github.com/GraysonCAdams",
+        "commits": 0
+      },
+      "contributors": [
+        {
+          "username": "GraysonAdams",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/1523519?v=4",
+          "profileUrl": "https://github.com/GraysonAdams",
+          "commits": 34
+        }
+      ],
+      "lastUpdated": "2026-01-06T05:07:49.712Z"
+    },
+    "linked-goals": {
+      "featureId": "linked-goals",
+      "ideator": {
+        "username": "GraysonCAdams",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/51373669?v=4",
+        "profileUrl": "https://github.com/GraysonCAdams",
+        "commits": 0
+      },
+      "contributors": [],
+      "lastUpdated": "2026-01-06T05:07:50.042Z"
+    },
+    "leaderboard": {
+      "featureId": "leaderboard",
+      "ideator": {
+        "username": "GraysonCAdams",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/51373669?v=4",
+        "profileUrl": "https://github.com/GraysonCAdams",
+        "commits": 0
+      },
+      "contributors": [],
+      "lastUpdated": "2026-01-06T05:07:50.143Z"
+    }
+  }
+}

--- a/scripts/contributors-gen/cache.json
+++ b/scripts/contributors-gen/cache.json
@@ -1,0 +1,18 @@
+{
+  "users": {
+    "grayson@graysonadams.com": {
+      "email": "grayson@graysonadams.com",
+      "username": "GraysonAdams",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1523519?v=4",
+      "profileUrl": "https://github.com/GraysonAdams",
+      "fetchedAt": "2026-01-05T17:21:42.071Z"
+    },
+    "51373669+graysoncadams@users.noreply.github.com": {
+      "email": "51373669+graysoncadams@users.noreply.github.com",
+      "username": "GraysonCAdams",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/51373669?v=4",
+      "profileUrl": "https://github.com/GraysonCAdams",
+      "fetchedAt": "2026-01-05T17:21:42.147Z"
+    }
+  }
+}


### PR DESCRIPTION
Automated contributor data update.

This PR updates:
- `frontend/src/data/contributors.json` - Contributor attribution data
- `scripts/contributors-gen/cache.json` - GitHub user cache

🤖 Generated by the Contributors Generator workflow