### PR TITLE
fix(ci): use macos-13 for x64 builds instead of macos-15-large

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -85,7 +85,7 @@ jobs:
         include:
           - runner: macos-15
             arch: arm64
-          - runner: macos-15-large
+          - runner: macos-13
             arch: x64
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
@@ -202,7 +202,7 @@ jobs:
           - runner: macos-15
             arch: arm64
             backend_artifact: backend-mac-arm64
-          - runner: macos-15-large
+          - runner: macos-13
             arch: x64
             backend_artifact: backend-mac-x64
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
## Summary

Switch from `macos-15-large` (requires larger runner billing) to `macos-13` for x64 macOS builds. This avoids billing issues while still providing x64 build capability.

## Changes

- Changed `macos-15-large` to `macos-13` for x64 backend builds
- Changed `macos-15-large` to `macos-13` for x64 package builds

## Test plan

- [ ] Beta release workflow should complete successfully without billing errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)