### PR TITLE
fix(ci): use macos-15-intel for x64 builds

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -85,7 +85,7 @@ jobs:
         include:
           - runner: macos-15
             arch: arm64
-          - runner: macos-13
+          - runner: macos-15-intel
             arch: x64
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
@@ -202,7 +202,7 @@ jobs:
           - runner: macos-15
             arch: arm64
             backend_artifact: backend-mac-arm64
-          - runner: macos-13
+          - runner: macos-15-intel
             arch: x64
             backend_artifact: backend-mac-x64
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
## Summary

macOS-13 runners are now retired. Use macos-15-intel for x64 builds as suggested in the GitHub Actions deprecation notice.

## Changes

- Changed `macos-13` to `macos-15-intel` for x64 backend builds
- Changed `macos-13` to `macos-15-intel` for x64 package builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)