### PR TITLE
update: remove deprecated @types/react-grid-layout

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.1.5",
+  "version": "1.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.1.5",
+      "version": "1.3.10",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -19,7 +19,6 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@reactour/tour": "^3.8.0",
         "@tanstack/react-query": "^5.90.16",
-        "@types/react-grid-layout": "^1.3.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "frimousse": "^0.3.0",
@@ -4441,15 +4440,6 @@
       "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@types/react-grid-layout": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@types/react-grid-layout/-/react-grid-layout-1.3.6.tgz",
-      "integrity": "sha512-Cw7+sb3yyjtmxwwJiXtEXcu5h4cgs+sCGkHwHXsFmPyV30bf14LeD/fa2LwQovuD2HWxCcjIdNhDlcYGj95qGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/unist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,6 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@reactour/tour": "^3.8.0",
     "@tanstack/react-query": "^5.90.16",
-    "@types/react-grid-layout": "^1.3.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "frimousse": "^0.3.0",


### PR DESCRIPTION
## Summary
- Remove `@types/react-grid-layout` from dependencies — `react-grid-layout` ships its own types since v2
- The `@types` package v2 is a [deprecated stub](https://www.npmjs.com/package/@types/react-grid-layout) that just re-exports the built-in types
- Replaces Renovate PR #243 which was upgrading to the deprecated stub

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` — 488 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)